### PR TITLE
Add AI bot opt-out (robots.txt + noai meta tag)

### DIFF
--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -1,0 +1,32 @@
+User-agent: *
+Allow: /
+
+User-agent: AI2Bot
+User-agent: Amazonbot
+User-agent: anthropic-ai
+User-agent: Applebot-Extended
+User-agent: Bytespider
+User-agent: CCBot
+User-agent: ChatGPT-User
+User-agent: ClaudeBot
+User-agent: Claude-Web
+User-agent: cohere-ai
+User-agent: cohere-training-data-crawler
+User-agent: Diffbot
+User-agent: FacebookBot
+User-agent: Google-Extended
+User-agent: Google-CloudVertexBot
+User-agent: GPTBot
+User-agent: ImagesiftBot
+User-agent: Kangaroo Bot
+User-agent: Meta-ExternalAgent
+User-agent: Meta-ExternalFetcher
+User-agent: Omgili
+User-agent: Omgilibot
+User-agent: PerplexityBot
+User-agent: Timpibot
+User-agent: Webzio-Extended
+User-agent: YouBot
+Disallow: /
+
+Sitemap: https://documentation.secondstage.io/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ extra_javascript:
 
 theme:
   name: material
+  custom_dir: overrides
   logo: assets/2s-logo.png
   favicon: assets/favicon.png
   font:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+  <meta name="robots" content="noai, noimageai">
+{% endblock %}


### PR DESCRIPTION
## Summary

Adds advisory opt-out signals against AI training crawlers — mirrors the protection we just added to secondstage.io. GitHub Pages has no firewall layer, so robots.txt + meta tags are the only available mechanism here.

- **`docs/robots.txt`** — disallow 26 known AI training crawlers (BAK opt-out list); MkDocs copies it to site root on build.
- **`overrides/main.html`** — extends `material/base.html` to inject `<meta name="robots" content="noai, noimageai">` into every page head (additional signal some bots respect).
- **`mkdocs.yml`** — register `theme.custom_dir: overrides` so the template override is picked up.

## Limitations (be aware)

robots.txt and meta tags are **advisory only** — sophisticated AI scrapers ignore both. There's no equivalent of Vercel BotID or Firewall on GitHub Pages. If stronger enforcement is needed later, the docs site would need to move to Vercel.

## Test plan

- [ ] After merge: `curl https://documentation.secondstage.io/robots.txt` returns the disallow list (was 404 before)
- [ ] View page source on any doc page → `<meta name="robots" content="noai, noimageai">` present in `<head>`
- [ ] Site builds successfully (no MkDocs errors from custom_dir)
- [ ] Theme/styling unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)