### PR TITLE
Additional fixes: dev tooling, header/nav polish, landing copy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: dev build clean
+
+VENV    ?= .venv
+MKDOCS   = $(VENV)/bin/mkdocs
+ENV      = DISABLE_MKDOCS_2_WARNING=true
+
+# Live-reload dev server. --livereload must be explicit: MkDocs 1.6.1's
+# Click CLI has a flag_value bug where the default=True is not honored
+# when neither --livereload nor --no-livereload is passed.
+dev:
+	$(ENV) $(MKDOCS) serve --livereload --dev-addr 127.0.0.1:8000
+
+# Strict build — same check CI runs on every PR.
+build:
+	$(ENV) $(MKDOCS) build --clean --strict
+
+clean:
+	rm -rf site

--- a/README.md
+++ b/README.md
@@ -1,17 +1,74 @@
-# tracks-documentation
-Documentation Repo for Tracks
+# TRACKS Documentation
 
+Public documentation site for [TRACKS](https://tracks.secondstage.io/) — Second Stage's attribution and marketing-intelligence platform for PC and console games. The built site is published at [documentation.secondstage.io](https://documentation.secondstage.io).
 
-## Mkdocs material documentation
-https://squidfunk.github.io/mkdocs-material/
+Built with [MkDocs](https://www.mkdocs.org/) and the [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/) theme.
 
+## Hosting
 
-### Examples & Setup
+- **Production**: Vercel, deployed from `main` on every push.
+- **Previews**: Vercel preview deployments on every pull request, linked in the PR's Checks panel.
+- **CI**: a GitHub Actions workflow (`.github/workflows/ci.yml`) runs `mkdocs build --strict` on every PR to catch broken internal links, missing images, invalid YAML, and plugin misconfiguration before merge.
 
-https://squidfunk.github.io/mkdocs-material/setup/
+## Local development
 
+Requires Python 3.11+ (tested on 3.13).
 
-Deploys automatically from gh-pages branch
+```bash
+# One-time setup
+python3 -m venv .venv
+.venv/bin/pip install -r requirements.txt
 
+# Run the live-reload dev server
+make dev
+```
 
+Open `http://127.0.0.1:8000/` in a browser. Edits under `docs/` auto-reload. Changes to `mkdocs.yml`, `overrides/`, or `hooks/` require restarting the server (`Ctrl+C` then `make dev` again).
 
+### Other Make targets
+
+| Command | What it does |
+|---|---|
+| `make dev` | Live-reload dev server on `127.0.0.1:8000` |
+| `make build` | Strict build — same check CI runs on every PR |
+| `make clean` | Remove the `site/` output directory |
+
+Always use `make dev` rather than `mkdocs serve` directly — there is a flag-parsing quirk in MkDocs 1.6.1 that silently disables the file watcher unless `--livereload` is passed explicitly, which the Makefile handles.
+
+## Repo layout
+
+```
+docs/                 Markdown sources + static assets
+  assets/             Images, screenshots, diagrams, logos
+  javascripts/        Site JS (Helpscout Beacon, feedback widget)
+  stylesheets/        Custom CSS
+  robots.txt          Bot opt-out list
+overrides/            Material theme overrides
+  partials/           Custom header, footer, feedback widget
+  main.html           Injects noai / noimageai meta tags
+hooks/                MkDocs build hooks
+  recent_updates.py   Parses changelog.md and injects recent entries on the landing page
+mkdocs.yml            Site config, navigation, plugins, redirects
+requirements.txt      Pinned Python dependencies (mkdocs, material, glightbox, redirects)
+vercel.json           Vercel build config
+.github/workflows/    CI (build-strict check)
+Makefile              Dev shortcuts
+```
+
+## Configuring navigation
+
+The left sidebar and top-level sections are defined in the `nav:` block at the bottom of `mkdocs.yml`. Adding a new page means:
+
+1. Create the Markdown file under `docs/…`.
+2. Add an entry to `nav:` so it appears in the sidebar.
+3. Run `make build` locally to verify the strict build still passes.
+
+When a page moves or is renamed, add an entry to `plugins.redirects.redirect_maps` in `mkdocs.yml` so existing external links (bookmarks, emails, search results) keep working.
+
+## Deploying
+
+Merging a pull request into `main` triggers a Vercel production deployment automatically. No manual deploy step.
+
+## License / ownership
+
+&copy; Second Stage GmbH. Content is proprietary; see the site footer for legal notices and imprint.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@
   <p>Integration guides, API references, and operational playbooks for the TRACKS attribution and marketing-intelligence platform for PC and console games.</p>
 </section>
 
-<h2 id="start-a-journey" class="docs-home__label">Start a journey</h2>
+<h2 id="start-your-journey" class="docs-home__label">Start your journey</h2>
 
 <p class="docs-home__lede">Most customers move through these in order: <strong>Set up</strong> provisions the cloud environment and connects your ad platforms, landing page, and storefronts; <strong>Configure</strong> wires attribution and postbacks; <strong>Operate</strong> covers day-to-day campaign work. If you're not sure where you are, start with "Set up TRACKS".</p>
 

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -363,9 +363,29 @@ body, .md-typeset { font-size-adjust: none; }
   width: 1.1rem;
   height: 1.1rem;
 }
+@media screen and (min-width: 60em) {
+  .md-header__button.md-icon[for="__search"] {
+    background-color: var(--md-primary-bg-color);
+    border: 1px solid var(--md-rule-color);
+    padding: 0.3rem 0.55rem;
+    height: 1.85rem;
+    width: auto;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.02);
+  }
+  [data-md-color-scheme="slate"] .md-header__button.md-icon[for="__search"] {
+    background-color: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: none;
+  }
+}
 .md-header__button.md-icon[for="__search"]:hover {
   background-color: rgba(0, 0, 0, 0.05);
   color: var(--md-primary-fg-color) !important;
+}
+@media screen and (min-width: 60em) {
+  .md-header__button.md-icon[for="__search"]:hover {
+    border-color: var(--md-primary-fg-color);
+  }
 }
 .md-header__button.md-icon[for="__search"]:hover svg,
 .md-header__button.md-icon[for="__search"]:hover svg * {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -335,16 +335,26 @@ body, .md-typeset { font-size-adjust: none; }
   }
 }
 
+/* Mobile: group the search icon with the right cluster, left of the
+   palette toggle. Orders: burger=-1, wordmark=0, spacer=1, search=3,
+   palette=4, CTA=5. */
+@media screen and (max-width: 59.99em) {
+  .md-header__button.md-icon[for="__search"] { order: 3; }
+}
+
 /* Right cluster: palette → CTA, pushed to the edge */
 .md-header .md-header__option,
 .md-header form.md-header__option { order: 4; }
 .md-header .tracks-header-cta { order: 5; }
 
-/* Search icon — full foreground color for clear visibility in both schemes */
+/* Search trigger — on desktop, render as a pill with a visible surface
+   and border so it stays legible over the translucent blurred header
+   regardless of what content scrolls behind. Mobile stays as a plain
+   icon since it sits in the right cluster with the other icon buttons. */
 .md-header__button.md-icon[for="__search"] {
   color: var(--md-text-color) !important;
   border-radius: 999px;
-  transition: background-color 0.15s, color 0.15s;
+  transition: background-color 0.15s, color 0.15s, border-color 0.15s;
 }
 .md-header__button.md-icon[for="__search"] svg,
 .md-header__button.md-icon[for="__search"] svg * {
@@ -455,12 +465,11 @@ body, .md-typeset { font-size-adjust: none; }
 }
 
 /* --- Sidebar nav — full collapsible tree -------------------------------- */
-/* On desktop the header wordmark already says "TRACKS Documentation",
-   so suppress the duplicate inside the sidebar. On mobile the drawer
-   needs this row (it contains the close-arrow), so keep it visible. */
-@media screen and (min-width: 76.25em) {
-  .md-nav--primary .md-nav__title { display: none; }
-}
+/* The header wordmark already says "TRACKS Documentation"; suppress the
+   duplicate title row in both the desktop sidebar and the mobile drawer.
+   The site uses no navigation.sections, so there's no drill-in panel
+   stack that would need a back-arrow in this row. */
+.md-nav--primary .md-nav__title { display: none; }
 
 .md-nav__link {
   font-size: var(--nav-item-font-size);

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -108,10 +108,17 @@ body, .md-typeset { font-size-adjust: none; }
   padding-left: 1rem;
   padding-right: 1rem;
 }
+/* Desktop: move the gutter up to .md-main__inner so the header logo,
+   the sidebar, and the content column all share the same left/right
+   inset as the header inner (1.5rem). Avoids double-padding. */
 @media screen and (min-width: 60em) {
-  .md-content__inner {
+  .md-main__inner {
     padding-left: 1.5rem;
     padding-right: 1.5rem;
+  }
+  .md-content__inner {
+    padding-left: 0;
+    padding-right: 0;
   }
 }
 
@@ -282,7 +289,7 @@ body, .md-typeset { font-size-adjust: none; }
   gap: 0.15rem;
   width: auto;
   height: auto;
-  padding: 0 0.25rem;
+  padding: 0;
   margin: 0;
   text-decoration: none;
   transition: opacity 0.15s;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_url: https://documentation.secondstage.io
 
 # Update version to force new CSS to load
 extra_css:
-  - stylesheets/extra.css?v=57
+  - stylesheets/extra.css?v=61
 
 extra_javascript:
   - javascripts/extra.js


### PR DESCRIPTION
## Summary
Five focused fixes on top of the layout-improvements merge.

- **Dev tooling**: `Makefile` with `make dev` / `make build` / `make clean`, and a real README. `make dev` works around a Click flag bug in MkDocs 1.6.1 that silently disables livereload.
- **Mobile nav**: hide the duplicate "TRACKS Documentation" title row at the top of the drawer; move the search icon from the middle of the header into the right-hand icon cluster (left of the palette toggle).
- **Desktop search trigger**: render as a visible pill with a 1px border + subtle surface so it stays legible inside the translucent blurred header regardless of what scrolls behind. Hover border turns brand-red.
- **Header/content alignment**: the header logo sat ~1.3rem to the right of the sidebar nav's left edge. Move the gutter from `.md-content__inner` up to `.md-main__inner` so header, sidebar, and content column share the same 1.5rem inset on desktop; drop the wordmark's extra inner padding. Bumps the cache-buster to `v=61`.
- **Landing copy**: "Start a journey" → "Start your journey" (anchor id updated to match).

## Test plan
- [ ] Vercel preview renders cleanly in light and dark modes
- [ ] Mobile drawer: no brand-color row at the top; menu starts at "Home"
- [ ] Mobile header: search icon sits left of the dark-mode toggle
- [ ] Desktop header: search icon reads as a pill button in both modes; hover turns border red
- [ ] Desktop header: TRACKS logo left-edge aligns with the sidebar nav left-edge
- [ ] Landing heading reads "Start your journey"
- [ ] `make dev` boots the server and live-reload fires on edits under `docs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)