### PR TITLE
docs: correct event data retention to 9 months, clarify what reporting exposes

### DIFF
--- a/docs/support/datacollection.md
+++ b/docs/support/datacollection.md
@@ -55,13 +55,13 @@ Retention is tiered. The raw request logs and the event data derived from them a
 | Data | Retention |
 | :--- | :--- |
 | **Raw logs** (`collect_logs`, `measure_logs`) — the granular request-level records described above | **30 days**, then automatically deleted. |
-| **Event data** — pseudonymized event rows holding salt-hashed IPs, pseudonymized `user_id`s, and event parameters (storefront, platform, acquisition source) | **18 months by default**, resetting on new activity from the same `user_id`. Configurable to your own retention policy on request. |
+| **Event data** — pseudonymized event rows holding salt-hashed IPs, pseudonymized `user_id`s, and event parameters (storefront, platform, acquisition source) | **9 months by default**, resetting on new activity from the same `user_id`. Configurable to your own retention policy on request. |
 
 Both tiers live in your own BigQuery dataset. A "forget API" is available to delete all records associated with a given `user_id` on request, across both tiers — see [GDPR API](../attribution/gdprapi.md).
 
 !!! warning "Reflect your configured period in your privacy policy"
 
-    The 18-month figure is the default. If you have asked us to change it, state your actual configured period in your privacy policy and records of processing — not the default.
+    The 9-month figure is the default. If you have asked us to change it, state your actual configured period in your privacy policy and records of processing — not the default.
 
 ## Technical Notes
 

--- a/docs/support/datacollection.md
+++ b/docs/support/datacollection.md
@@ -41,6 +41,15 @@ This page describes how TRACKS collects and processes data through its two API e
 Records from `/measure` can be matched to `/collect` logs using the salt-hashed IP address.  
 This enables user-level telemetry by linking game activity to prior visits.
 
+### What reporting exposes
+
+The user-level data described above stays in your own dataset. How it surfaces depends on which interface you use:
+
+- **TRACKS Reporting Suite** — aggregated reporting only. No `user_id`-level report is available in the reporting UI.
+- **Reporting API** — can expose `user_id`s where you need that granularity. It reads exclusively from your own datalake, never from Second Stage infrastructure.
+
+This is why only anonymized, aggregated data reaches the Second Stage datalake, as described in [Architecture](architecture.md#hybrid-hosted-deployment).
+
 ## Data Storage and Security
 
 - Data storage is handled on a server deployed on the client side.  

--- a/docs/support/datasecurity.md
+++ b/docs/support/datasecurity.md
@@ -41,7 +41,7 @@ TRACKS adheres to the principle of data minimization by collecting only what is 
 | **Hashed IP Addresses** | IP addresses are never stored in plain text. They are cryptographically salted and hashed immediately upon receipt. |
 | **Salt Rotation** | The "salt" used for hashing is rotated regularly, preventing long-term re-identification or cross-referencing of users. |
 | **30-Day Raw Log Retention** | The raw logs used for attribution (`collect_logs` and `measure_logs`) are automatically deleted after 30 days. |
-| **18-Month Event Data Retention** | The pseudonymized event data derived from those logs — salt-hashed IPs, pseudonymized `user_id`s, and event parameters — is retained for 18 months by default, resetting on new activity from the same `user_id`. Configurable to your own retention policy on request. |
+| **9-Month Event Data Retention** | The pseudonymized event data derived from those logs — salt-hashed IPs, pseudonymized `user_id`s, and event parameters — is retained for 9 months by default, resetting on new activity from the same `user_id`. Configurable to your own retention policy on request. |
 | **Encryption** | All data is encrypted during transmission (TLS) and at rest on your servers. |
 
 Both retention tiers sit in your own BigQuery dataset, and the [Right to Forget](#right-to-forget) API clears a given `user_id` from both. For the field-level breakdown, see [Data Collection and Processing](datacollection.md#data-deletion-and-retention).
@@ -94,8 +94,8 @@ To ensure transparency, you should disclose the use of TRACKS in your privacy po
     The data is processed for the purpose of analyzing the use of our website and our products, optimizing our offering, and to evaluate the effectiveness of our marketing and sales channels. In addition, the pseudonymous linking of website visits and product usage events enables better technical control and error analysis of our offering.
 
     **5. Duration of storage**
-    The raw access and event logs are stored pseudonymously and automatically deleted after 30 days. The pseudonymized event data derived from them — salt-hashed IP addresses, pseudonymized user IDs, and the associated event parameters — is stored for a maximum of 18 months from the last recorded activity and is then deleted. Data subjects can request erasure of the data relating to them at any time, using the contact details given in this privacy policy.
+    The raw access and event logs are stored pseudonymously and automatically deleted after 30 days. The pseudonymized event data derived from them — salt-hashed IP addresses, pseudonymized user IDs, and the associated event parameters — is stored for a maximum of 9 months from the last recorded activity and is then deleted. Data subjects can request erasure of the data relating to them at any time, using the contact details given in this privacy policy.
 
 !!! warning "Check the retention figures before you publish"
 
-    The 30-day and 18-month periods above are the TRACKS defaults. If your event data retention has been configured differently, state your actual period. Publishing a shorter period than you operate is an Art. 13 accuracy problem, so confirm the configured value with us before adopting this text.
+    The 30-day and 9-month periods above are the TRACKS defaults. If your event data retention has been configured differently, state your actual period. Publishing a shorter period than you operate is an Art. 13 accuracy problem, so confirm the configured value with us before adopting this text.


### PR DESCRIPTION
## Summary

Closes the two open verification items from the privacy alignment review (#278, #279) that came back with corrections.

**Event data retention is 9 months, not 18.** The 18-month figure originated in the website FAQ, which is wrong. Confirmed with the data/pipeline owner. Corrected in both retention tables, both admonitions, and section 5 of the example privacy policy text — the last one matters most, because customers publish that period under their own name.

**Reporting exposure is interface-dependent.** The docs said the platform enables "user-level telemetry"; the website FAQ said reporting is aggregate-only. Both were true about different things. Confirmed with the reporting owner: the Reporting Suite is aggregated only, the Reporting API can expose `user_id`s where needed, and the API reads exclusively from the customer's own datalake — never from Second Stage infrastructure. Stated explicitly, because it is also what makes the "only anonymized aggregates reach Second Stage" position hold.

Also verified and needing no change: both retention tiers are customer-side, the Forget API spans both tiers, only anonymized aggregates reach the Second Stage datalake, and differential privacy is not implemented anywhere.

## Test Plan

- [x] `make build` (strict, same check CI runs) passes after each commit — exit 0, no link or nav warnings
- [x] `grep -rn "18 month\|18-Month\|18-month" docs/` returns nothing
- [x] New anchor `architecture.md#hybrid-hosted-deployment` resolves under `--strict`
- [x] The 9-month figure appears consistently in both retention tables, both admonitions, and the policy template

## Follow-up not in this PR

- The website FAQ still states 18 months and needs the same correction (`src/lib/data/faq.ts`)
- Scope of what `analytics@secondstage.io` can read in a customer project — still open, parked by request

🤖 Generated with [Claude Code](https://claude.com/claude-code)