### PR TITLE
docs: describe the access model accurately

### DIFF
--- a/docs/support/architecture.md
+++ b/docs/support/architecture.md
@@ -14,7 +14,7 @@ TRACKS attribution combines four sources, all consolidated into a partitioned Bi
 - **Steamworks UTM analytics** — traffic and click-through data from Steam.
 - **TRACKS Measurement API** — in-game `game_open` and `session_start` events forwarded from your telemetry backend.
 
-Media platforms, GA4 (via GTM), and Steamworks integrate by granting access to our service account `analytics@secondstage.io`. The Measurement API is the exception — it runs inside your own GCP environment (more on that below).
+Media platforms, GA4 (via GTM), and Steamworks are integrated by granting access to `analytics@secondstage.io`, a named Second Stage account. These platforms authenticate via OAuth user login and cannot accept a service account, so a named account is the only option available. The Measurement API is the exception — it runs inside your own GCP environment and is operated by a dedicated service account (more on that below).
 
 Once the ELT pipeline is in place, every source feeds a partitioned BigQuery table. Data retention and GDPR specifics are covered in [Data Handling & Security](datasecurity.md).
 
@@ -25,7 +25,7 @@ Once the ELT pipeline is in place, every source feeds a partitioned BigQuery tab
 
 ## Hybrid-hosted deployment
 
-The TRACKS Measurement API is **deployed into your [Google Cloud Platform](../glossary.md#g) project**, not ours. All granular per-user data — IPs, pseudonymized user IDs, event timestamps — is processed and stored on your own GCP. Second Stage's service account holds only the permissions needed to run and update the pipeline.
+The TRACKS Measurement API is **deployed into your [Google Cloud Platform](../glossary.md#g) project**, not ours. All granular per-user data — IPs, pseudonymized user IDs, event timestamps — is processed and stored on your own GCP. Deployment and pipeline operation are carried out by a dedicated Google Cloud service account that authenticates with its own credentials and is never used for interactive sign-in. You grant the roles it holds in your project, and you can reduce them to a least-privilege set once the deployment is validated.
 
 Only **anonymized, aggregated** results cross the boundary into the Second Stage datalake, which is the layer the [Reporting Suite](../overview/functionality.md) reads from. Per-user records, hashed identifiers, and raw logs stay inside your project — they are never copied to Second Stage.
 

--- a/docs/support/datasecurity.md
+++ b/docs/support/datasecurity.md
@@ -52,6 +52,7 @@ For the highest level of security and transparency, TRACKS operates on a scalabl
 
 * **Your Cloud Environment:** Our deployment method uses your own configured Google Cloud project. Services include Cloud Storage, Cloud Run, Pub/Sub, and Cloud Functions.
 * **Full Control:** You decide the server location (e.g., EU-only data centers), access rights, and security configurations.
+* **Access Model:** TRACKS is deployed into your Google Cloud project by a dedicated service account that authenticates with its own credentials and is never used for interactive sign-in. Where a platform's API cannot accept a service account — Google Ads, Meta, GA4 and Steamworks all authenticate via OAuth user login — access is granted to a named Second Stage account instead. You grant the roles held in your project, and you can reduce them to a least-privilege set once deployment is validated.
 * **No External Transfer of Personal Data:** Personal data is sent directly to your server endpoints. TRACKS does not collect or mirror it on Second Stage servers. Only **anonymized, aggregated** results — figures that cannot be traced back to an individual player — are passed to the Second Stage datalake that powers the TRACKS Reporting Suite. No per-user records, hashed identifiers, or raw logs leave your project.
 
 ## PII & Global Compliance (CCPA, CPRA)


### PR DESCRIPTION
## Summary

Closes verification item 5 from the privacy alignment review.

`architecture.md` described `analytics@secondstage.io` as "our service account". It is a named Second Stage account, not a service account — and that distinction is precisely what a reviewing DPO asks about, since a service account is credential-based and non-interactive while a named account can be signed into.

The two access paths are now stated separately:

- **GCP deployment and pipeline operation** — a dedicated Google Cloud service account, authenticating with its own credentials, never used for interactive sign-in.
- **Platforms that cannot accept a service account** — Google Ads, Meta, GA4 and Steamworks authenticate via OAuth user login, so a named Second Stage account is the only option.

Both descriptions now also note that the customer grants the roles held in their project and can reduce them to a least-privilege set once deployment is validated, which is what we already tell clients during onboarding.

## Test Plan

- [x] `make build` (strict, same check CI runs) passes — exit 0
- [x] No remaining description of `analytics@secondstage.io` as a service account: `grep -rn "our service account" docs/` returns nothing
- [x] Both access paths described consistently in `architecture.md` and `datasecurity.md`

## Not in this PR

The steady-state IAM roles granted in a customer project remain an open question, and the GDPR processor classification stays under legal review pending that answer. No claim about processor status is changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)